### PR TITLE
Track uh forecast accuracy and sla

### DIFF
--- a/query_validation_notes.md
+++ b/query_validation_notes.md
@@ -1,0 +1,72 @@
+# UH Forecast SLA Dashboard - Query Modifications
+
+## Changes Made
+
+### 1. Removed Backtesting Components ✅
+- Removed all commented `backtest_pred` CTE
+- Removed `actuals_vs_backtest` CTE  
+- Removed union with backtesting data in `combined` CTE
+- Cleaned up all backtesting references
+
+### 2. Implemented Dynamic SLA Logic ✅
+- **W0 (horizon = 0)**: Error threshold < 0.3%, requires 11/13 weeks hitting SLA
+- **W1-4 (horizon 1-4)**: Error threshold < 0.3%, requires 100% SLA hit rate
+- **W5-13 (horizon 5-13)**: Error threshold < 0.45%, requires 100% SLA hit rate
+
+### 3. Added SLA Tracking Features ✅
+- Dynamic `sla_threshold` calculation based on horizon
+- Updated `within_SLA` logic to use dynamic thresholds
+- Added SLA performance summaries for W0 and W1-13
+- Created dashboard-ready output with SLA status indicators
+
+## Key Query Files
+
+### `uh_forecast_sla_dashboard.sql`
+- Main query with all original functionality
+- Includes dynamic SLA thresholds
+- Maintains long format output for flexibility
+- Includes commented SLA summary sections
+
+### `uh_forecast_sla_dashboard_summary.sql` 
+- Dashboard-focused query
+- Provides SLA performance summaries by horizon group
+- Includes health score calculations
+- Ready for dashboard consumption
+
+## SLA Logic Implementation
+
+```sql
+-- Dynamic SLA thresholds
+case 
+  when horizon = 0 then 0.3 / 100      -- W0: 0.3%
+  when horizon between 1 and 4 then 0.3 / 100   -- W1-4: 0.3%  
+  when horizon between 5 and 13 then 0.45 / 100  -- W5-13: 0.45%
+  else 0.45 / 100
+end as sla_threshold
+
+-- SLA Status Logic
+case 
+  when horizon = 0 and forecasts_hitting_sla >= 11 and total_forecasts >= 13 then 'PASS'
+  when horizon = 0 then 'FAIL'
+  when horizon between 1 and 13 and sla_hit_rate = 1.0 then 'PASS'
+  when horizon between 1 and 13 then 'FAIL'
+  else 'N/A'
+end as sla_status
+```
+
+## Dashboard Outputs
+
+1. **SLA Summary**: Performance by horizon group and submarket
+2. **Weekly Trend**: Time series of SLA performance  
+3. **Health Score**: Overall forecast quality assessment
+4. **Detailed Metrics**: All original metrics plus SLA indicators
+
+## Validation Checklist
+
+- [x] Backtesting code removed
+- [x] Dynamic SLA thresholds implemented
+- [x] W0 special logic (11/13 weeks) implemented
+- [x] W1-4 and W5-13 standard SLA logic implemented
+- [x] Dashboard-ready summary created
+- [x] Original functionality preserved
+- [x] Query structure validated

--- a/uh_forecast_sla_dashboard.sql
+++ b/uh_forecast_sla_dashboard.sql
@@ -1,0 +1,234 @@
+-- UH Forecast vs Actuals Dashboard with SLA Tracking
+-- SLA Definition:
+-- w0 forecast: more than 11/13 weeks hitting SLA (error < 0.3%)
+-- w1-4: error < 0.3%
+-- w5-13: error < 0.45%
+
+with uh_fcst as (
+select distinct
+  '1_Actuals_vs_Forecasts' as category
+  , a.active_week
+  , a.scenario
+  , a.config
+  , a.submarket_id
+  , a.horizon
+  , a.pred_uh_no_dac_no_dxo / 100 as pred_uh_no_dac_no_dxo
+  , a.pred_uh_no_dac / 100 as pred_uh_no_dac
+  , a.pred_uh / 100 as pred_uh
+from martech.dasher.dac_optimizer_uh_forecast_v2 a
+-- filter on locked versions only
+inner join martech.dasher.dac_optimizer_full_executed_config b 
+  on a.active_week = b.active_week 
+  and substring(a.scenario, 1, 18) = substring(b.scenario, 1, 18) 
+  and a.config = b.config
+where submarket_id != 0 -- exclude global UH fcst
+)
+
+, actual_uh as (
+select
+  date_trunc('week', local_hour) as week
+  , a.submarket_id
+  , div0(sum(total_hours_undersupply), nullif(sum(total_hours_online_ideal),0)) as actual_uh
+  , sum(total_hours_undersupply) as undersupplied_hours
+  , sum(total_hours_online_ideal) as ideal_online_hours
+  , sum(total_deliveries) as total_delivs
+from edw.dasher.view_agg_supply_metrics_sp_hour a
+where 1=1
+  and date_trunc('week', local_hour) between '2025-01-01' and dateadd('week', -1, date_trunc('week', current_date))
+group by all
+)
+
+, actuals_vs_forecasts as (
+select
+  'Forecasts' as metric_cat
+  , 1 as metric_cat_order
+  , a.active_week as forecast_created_week
+  , dateadd('week', a.horizon, a.active_week) as forecast_week
+  , a.horizon
+  , a.scenario
+  , a.config
+  , a.submarket_id
+  , a.pred_uh as fcst_uh
+  , b.actual_uh
+  , a.pred_uh - b.actual_uh as error
+  , abs(a.pred_uh - b.actual_uh) as error_abs 
+  , div0(a.pred_uh, b.actual_uh) - 1 as error_pct
+  , abs(error_pct) as error_abs_pct
+  -- Dynamic SLA thresholds based on horizon
+  , case 
+      when a.horizon = 0 then 0.3 / 100  -- w0: 0.3%
+      when a.horizon between 1 and 4 then 0.3 / 100  -- w1-4: 0.3%
+      when a.horizon between 5 and 13 then 0.45 / 100  -- w5-13: 0.45%
+      else 0.45 / 100  -- default for horizons > 13
+    end as sla_threshold
+  , case when error_abs <= sla_threshold then 1 else 0 end as within_SLA
+  , b.total_delivs
+  , b.ideal_online_hours
+from uh_fcst a
+left join actual_uh b on a.active_week = b.week and a.submarket_id = b.submarket_id
+)
+
+, submarket_level_summary as (
+select 
+  'Submarket' as aggregation_level
+  , metric_cat
+  , metric_cat_order
+  , forecast_created_week
+  , forecast_week
+  , horizon
+  , scenario
+  , config
+  , submarket_id
+  , fcst_uh
+  , actual_uh
+  , error
+  , error_abs 
+  , error_pct
+  , error_abs_pct
+  , sla_threshold
+  , within_SLA
+  , total_delivs
+  , ideal_online_hours
+  , case when total_delivs >= 2000 then '>=2k_delivs' else '<2k_delivs' end as large_sm_flag
+  , case 
+      when total_delivs < 2000 then '0-2k'
+      when total_delivs <= 10000 then '2k-10k'
+      when total_delivs <= 100000 then '10k-100k'
+      when total_delivs <= 500000 then '100k-500k'
+    else '500k+' end as total_delivs_bucket
+  , case 
+      when total_delivs < 2000 then '1'
+      when total_delivs <= 10000 then '2'
+      when total_delivs <= 100000 then '3'
+      when total_delivs <= 500000 then '4'
+    else '5' end as total_delivs_bucket_order
+from actuals_vs_forecasts
+where 1=1
+  and forecast_week <= dateadd('week', -1, date_trunc('week', current_date))
+)
+
+, global_level_summary as (
+select 
+  'Global' as aggregation_level
+  , metric_cat
+  , metric_cat_order
+  , forecast_created_week
+  , forecast_week
+  , horizon
+  , scenario
+  , config
+  , 0 as submarket_id
+  , sum(fcst_uh * ideal_online_hours) / sum(ideal_online_hours) as fcst_uh_agg
+  , sum(actual_uh * ideal_online_hours) / sum(ideal_online_hours) as actual_uh_agg
+  , fcst_uh_agg - actual_uh_agg as error_agg
+  , abs(fcst_uh_agg - actual_uh_agg) as error_abs_agg 
+  , div0(fcst_uh_agg, actual_uh_agg) - 1 as error_pct_agg
+  , abs(error_pct_agg) as error_abs_pct_agg
+  -- Use the same SLA threshold logic for global aggregation
+  , case 
+      when horizon = 0 then 0.3 / 100
+      when horizon between 1 and 4 then 0.3 / 100
+      when horizon between 5 and 13 then 0.45 / 100
+      else 0.45 / 100
+    end as sla_threshold_agg
+  , case when error_abs_agg <= sla_threshold_agg then 1 else 0 end as within_SLA 
+  , sum(total_delivs) total_delivs_agg
+  , sum(ideal_online_hours) ideal_online_hours_agg
+  , 'Global' as large_sm_flag
+  , 'Global' as total_delivs_bucket
+  , '0' as total_delivs_bucket_order
+from actuals_vs_forecasts
+where 1=1
+  and forecast_week <= dateadd('week', -1, date_trunc('week', current_date))
+group by all
+)
+
+, combined_with_flags as (
+select * from submarket_level_summary
+union all
+select * from global_level_summary
+)
+
+-- SLA Performance Summary for W0 (special case: needs 11/13 weeks hitting SLA)
+, w0_sla_performance as (
+select
+  aggregation_level
+  , scenario
+  , config
+  , submarket_id
+  , large_sm_flag
+  , total_delivs_bucket
+  , total_delivs_bucket_order
+  , count(*) as total_w0_forecasts
+  , sum(within_sla) as w0_forecasts_hitting_sla
+  , div0(w0_forecasts_hitting_sla, total_w0_forecasts) as w0_sla_hit_rate
+  , case when w0_forecasts_hitting_sla >= 11 and total_w0_forecasts >= 13 then 1 else 0 end as w0_overall_sla_met
+from combined_with_flags
+where horizon = 0
+  and forecast_week is not null
+  and actual_uh is not null
+group by all
+)
+
+-- SLA Performance Summary for W1-13 (standard SLA tracking)
+, w1_13_sla_performance as (
+select
+  aggregation_level
+  , scenario
+  , config
+  , submarket_id
+  , horizon
+  , large_sm_flag
+  , total_delivs_bucket
+  , total_delivs_bucket_order
+  , count(*) as total_forecasts
+  , sum(within_sla) as forecasts_hitting_sla
+  , div0(forecasts_hitting_sla, total_forecasts) as sla_hit_rate
+  , case 
+      when horizon between 1 and 4 and sla_hit_rate >= 1.0 then 1  -- 100% for w1-4
+      when horizon between 5 and 13 and sla_hit_rate >= 1.0 then 1  -- 100% for w5-13
+      else 0 
+    end as horizon_sla_met
+from combined_with_flags
+where horizon between 1 and 13
+  and forecast_week is not null
+  and actual_uh is not null
+group by all
+)
+
+, metric_base_long_format as (
+  select 'Actuals' as metric_cat, 0 as metric_cat_order, 0 as metric_name_order, forecast_created_week, forecast_week, horizon, scenario, config, submarket_id, within_sla, total_delivs, aggregation_level, large_sm_flag, ideal_online_hours, total_delivs_bucket, total_delivs_bucket_order, sla_threshold
+  , 'Actual_UH' as metric_name, actual_uh as metric_value from combined_with_flags union all
+  
+  select metric_cat, metric_cat_order, 1 as metric_name_order, forecast_created_week, forecast_week, horizon, scenario, config, submarket_id, within_sla, total_delivs, aggregation_level, large_sm_flag, ideal_online_hours, total_delivs_bucket, total_delivs_bucket_order, sla_threshold
+  , 'Forecast_UH' as metric_name, fcst_uh as metric_value from combined_with_flags union all
+  
+  select metric_cat, metric_cat_order, 2 as metric_name_order, forecast_created_week, forecast_week, horizon, scenario, config, submarket_id, within_sla, total_delivs, aggregation_level, large_sm_flag, ideal_online_hours, total_delivs_bucket, total_delivs_bucket_order, sla_threshold
+  , 'Error' as metric_name, error as metric_value from combined_with_flags union all
+  
+  select metric_cat, metric_cat_order, 3 as metric_name_order, forecast_created_week, forecast_week, horizon, scenario, config, submarket_id, within_sla, total_delivs, aggregation_level, large_sm_flag, ideal_online_hours, total_delivs_bucket, total_delivs_bucket_order, sla_threshold
+  , 'Error_ABS' as metric_name, error_abs as metric_value from combined_with_flags union all
+  
+  select metric_cat, metric_cat_order, 4 as metric_name_order, forecast_created_week, forecast_week, horizon, scenario, config, submarket_id, within_sla, total_delivs, aggregation_level, large_sm_flag, ideal_online_hours, total_delivs_bucket, total_delivs_bucket_order, sla_threshold
+  , 'Error_PCT' as metric_name, error_pct as metric_value from combined_with_flags union all
+  
+  select metric_cat, metric_cat_order, 5 as metric_name_order, forecast_created_week, forecast_week, horizon, scenario, config, submarket_id, within_sla, total_delivs, aggregation_level, large_sm_flag, ideal_online_hours, total_delivs_bucket, total_delivs_bucket_order, sla_threshold
+  , 'Error_ABS_PCT' as metric_name, error_abs_pct as metric_value from combined_with_flags union all
+  
+  select metric_cat, metric_cat_order, 6 as metric_name_order, forecast_created_week, forecast_week, horizon, scenario, config, submarket_id, within_sla, total_delivs, aggregation_level, large_sm_flag, ideal_online_hours, total_delivs_bucket, total_delivs_bucket_order, sla_threshold
+  , 'SLA_Threshold' as metric_name, sla_threshold as metric_value from combined_with_flags union all
+  
+  select metric_cat, metric_cat_order, 7 as metric_name_order, forecast_created_week, forecast_week, horizon, scenario, config, submarket_id, within_sla, total_delivs, aggregation_level, large_sm_flag, ideal_online_hours, total_delivs_bucket, total_delivs_bucket_order, sla_threshold
+  , 'Within_SLA' as metric_name, within_sla as metric_value from combined_with_flags
+)
+
+-- Main output for dashboard
+select * from metric_base_long_format
+
+-- Uncomment below for SLA summary views:
+-- 
+-- -- W0 SLA Summary
+-- select 'W0_SLA_Summary' as report_type, * from w0_sla_performance
+-- 
+-- -- W1-13 SLA Summary  
+-- select 'W1_13_SLA_Summary' as report_type, * from w1_13_sla_performance

--- a/uh_forecast_sla_dashboard_summary.sql
+++ b/uh_forecast_sla_dashboard_summary.sql
@@ -1,0 +1,215 @@
+-- UH Forecast SLA Dashboard Summary
+-- This query provides dashboard-ready SLA tracking metrics
+
+with uh_fcst as (
+select distinct
+  a.active_week
+  , a.scenario
+  , a.config
+  , a.submarket_id
+  , a.horizon
+  , a.pred_uh / 100 as pred_uh
+from martech.dasher.dac_optimizer_uh_forecast_v2 a
+inner join martech.dasher.dac_optimizer_full_executed_config b 
+  on a.active_week = b.active_week 
+  and substring(a.scenario, 1, 18) = substring(b.scenario, 1, 18) 
+  and a.config = b.config
+where submarket_id != 0
+)
+
+, actual_uh as (
+select
+  date_trunc('week', local_hour) as week
+  , a.submarket_id
+  , div0(sum(total_hours_undersupply), nullif(sum(total_hours_online_ideal),0)) as actual_uh
+  , sum(total_hours_undersupply) as undersupplied_hours
+  , sum(total_hours_online_ideal) as ideal_online_hours
+  , sum(total_deliveries) as total_delivs
+from edw.dasher.view_agg_supply_metrics_sp_hour a
+where date_trunc('week', local_hour) between '2025-01-01' and dateadd('week', -1, date_trunc('week', current_date))
+group by all
+)
+
+, forecast_actuals as (
+select
+  a.active_week as forecast_created_week
+  , dateadd('week', a.horizon, a.active_week) as forecast_week
+  , a.horizon
+  , a.scenario
+  , a.config
+  , a.submarket_id
+  , a.pred_uh as fcst_uh
+  , b.actual_uh
+  , abs(a.pred_uh - b.actual_uh) as error_abs 
+  , case 
+      when a.horizon = 0 then 0.3 / 100
+      when a.horizon between 1 and 4 then 0.3 / 100
+      when a.horizon between 5 and 13 then 0.45 / 100
+      else 0.45 / 100
+    end as sla_threshold
+  , case when abs(a.pred_uh - b.actual_uh) <= sla_threshold then 1 else 0 end as within_SLA
+  , b.total_delivs
+  , b.ideal_online_hours
+  , case when b.total_delivs >= 2000 then 'Large (>=2k delivs)' else 'Small (<2k delivs)' end as submarket_size
+from uh_fcst a
+left join actual_uh b on a.active_week = b.week and a.submarket_id = b.submarket_id
+where dateadd('week', a.horizon, a.active_week) <= dateadd('week', -1, date_trunc('week', current_date))
+  and b.actual_uh is not null
+)
+
+-- Submarket Level SLA Performance
+, submarket_sla_summary as (
+select
+  'Submarket' as aggregation_level
+  , scenario
+  , config
+  , submarket_id
+  , submarket_size
+  , horizon
+  , case 
+      when horizon = 0 then 'W0 (Same Week)'
+      when horizon between 1 and 4 then 'W1-4 (Short Term)'
+      when horizon between 5 and 13 then 'W5-13 (Long Term)'
+      else 'W14+ (Extended)'
+    end as horizon_group
+  , count(*) as total_forecasts
+  , sum(within_sla) as forecasts_hitting_sla
+  , div0(forecasts_hitting_sla, total_forecasts) as sla_hit_rate
+  , avg(error_abs) as avg_error_abs
+  , median(error_abs) as median_error_abs
+  , max(sla_threshold) as sla_threshold
+  -- SLA Status based on requirements
+  , case 
+      when horizon = 0 and forecasts_hitting_sla >= 11 and total_forecasts >= 13 then 'PASS'
+      when horizon = 0 then 'FAIL'
+      when horizon between 1 and 13 and sla_hit_rate = 1.0 then 'PASS'
+      when horizon between 1 and 13 then 'FAIL'
+      else 'N/A'
+    end as sla_status
+from forecast_actuals
+where horizon <= 13
+group by all
+)
+
+-- Global Level SLA Performance  
+, global_sla_summary as (
+select
+  'Global' as aggregation_level
+  , scenario
+  , config
+  , 0 as submarket_id
+  , 'All Submarkets' as submarket_size
+  , horizon
+  , case 
+      when horizon = 0 then 'W0 (Same Week)'
+      when horizon between 1 and 4 then 'W1-4 (Short Term)'
+      when horizon between 5 and 13 then 'W5-13 (Long Term)'
+      else 'W14+ (Extended)'
+    end as horizon_group
+  , count(*) as total_forecasts
+  , sum(within_sla) as forecasts_hitting_sla
+  , div0(forecasts_hitting_sla, total_forecasts) as sla_hit_rate
+  -- Weighted averages for global metrics
+  , sum(error_abs * ideal_online_hours) / sum(ideal_online_hours) as avg_error_abs
+  , max(sla_threshold) as sla_threshold
+  , case 
+      when horizon = 0 and forecasts_hitting_sla >= 11 and total_forecasts >= 13 then 'PASS'
+      when horizon = 0 then 'FAIL'
+      when horizon between 1 and 13 and sla_hit_rate = 1.0 then 'PASS'
+      when horizon between 1 and 13 then 'FAIL'
+      else 'N/A'
+    end as sla_status
+from forecast_actuals
+where horizon <= 13
+  and ideal_online_hours > 0
+group by all
+)
+
+-- Combined SLA Dashboard Data
+, sla_dashboard_data as (
+select * from submarket_sla_summary
+union all
+select 
+  aggregation_level, scenario, config, submarket_id, submarket_size, horizon, horizon_group,
+  total_forecasts, forecasts_hitting_sla, sla_hit_rate, avg_error_abs, 
+  avg_error_abs as median_error_abs, sla_threshold, sla_status
+from global_sla_summary
+)
+
+-- Weekly SLA Trend (for time series dashboard)
+, weekly_sla_trend as (
+select
+  forecast_created_week
+  , horizon
+  , case 
+      when horizon = 0 then 'W0'
+      when horizon between 1 and 4 then 'W1-4'
+      when horizon between 5 and 13 then 'W5-13'
+    end as horizon_group
+  , scenario
+  , config
+  , count(*) as total_forecasts
+  , sum(within_sla) as forecasts_hitting_sla
+  , div0(forecasts_hitting_sla, total_forecasts) as weekly_sla_hit_rate
+  , avg(error_abs) as avg_weekly_error
+from forecast_actuals
+where horizon <= 13
+group by all
+)
+
+-- Overall SLA Health Score
+, sla_health_score as (
+select
+  scenario
+  , config
+  , -- W0 Score: 1 if >= 11/13 weeks hit SLA, 0 otherwise
+    max(case when horizon = 0 and sla_status = 'PASS' then 1 else 0 end) as w0_sla_score
+  , -- W1-4 Score: average SLA hit rate across horizons 1-4
+    avg(case when horizon between 1 and 4 then sla_hit_rate else null end) as w1_4_sla_score
+  , -- W5-13 Score: average SLA hit rate across horizons 5-13  
+    avg(case when horizon between 5 and 13 then sla_hit_rate else null end) as w5_13_sla_score
+  , -- Overall Health Score (weighted average)
+    (w0_sla_score * 0.4 + w1_4_sla_score * 0.3 + w5_13_sla_score * 0.3) as overall_health_score
+  , case 
+      when overall_health_score >= 0.9 then 'Excellent'
+      when overall_health_score >= 0.8 then 'Good' 
+      when overall_health_score >= 0.7 then 'Fair'
+      else 'Poor'
+    end as health_grade
+from sla_dashboard_data
+where aggregation_level = 'Global'
+group by all
+)
+
+-- Main Dashboard Output
+select 
+  'SLA_Summary' as report_type
+  , current_timestamp as report_generated_at
+  , *
+from sla_dashboard_data
+order by aggregation_level, scenario, config, horizon
+
+-- Uncomment sections below for additional dashboard views:
+
+-- union all
+-- select 
+--   'Weekly_Trend' as report_type
+--   , current_timestamp as report_generated_at
+--   , forecast_created_week, horizon, horizon_group, scenario, config
+--   , null as aggregation_level, null as submarket_id, null as submarket_size
+--   , total_forecasts, forecasts_hitting_sla, weekly_sla_hit_rate as sla_hit_rate
+--   , avg_weekly_error as avg_error_abs, null as median_error_abs
+--   , null as sla_threshold, null as sla_status
+-- from weekly_sla_trend
+-- order by forecast_created_week, horizon
+
+-- union all  
+-- select
+--   'Health_Score' as report_type
+--   , current_timestamp as report_generated_at
+--   , null as forecast_created_week, null as horizon, null as horizon_group
+--   , scenario, config, null as aggregation_level, null as submarket_id, null as submarket_size
+--   , null as total_forecasts, null as forecasts_hitting_sla
+--   , overall_health_score as sla_hit_rate, null as avg_error_abs, null as median_error_abs
+--   , null as sla_threshold, health_grade as sla_status
+-- from sla_health_score


### PR DESCRIPTION
Remove backtesting and add dynamic SLA thresholds to the UH forecast query, along with a new summary query for dashboard tracking.

This enables the team to build a dashboard to monitor UH forecast SLA performance against defined weekly targets (W0: <0.3% error, 11/13 weeks; W1-4: <0.3% error; W5-13: <0.45% error).

---
<a href="https://cursor.com/background-agent?bcId=bc-0c6ca07b-0bb2-4c8b-b44f-740fbee2e836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0c6ca07b-0bb2-4c8b-b44f-740fbee2e836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

